### PR TITLE
Please, enable SeaMonkey support back

### DIFF
--- a/plugin/chrome/content/notaries.js
+++ b/plugin/chrome/content/notaries.js
@@ -67,11 +67,24 @@ var Perspectives = {
 
 	//Sets the tooltip and the text of the favicon popup on https sites
 	setFaviconText: function(str){
-		document.getElementById("identity-box").tooltipText = str;
+        var box = document.getElementById("identity-box");
+        if(box)
+            box.tooltipText = str;
+        else { // SeaMonkey
+            box = document.getElementById("security-button");
+            if(box)
+                box.tooltipText = str;
+        }
 	},
 
 	getFaviconText: function(){
-		return document.getElementById("identity-box").tooltipText;
+        var box = document.getElementById("identity-box");
+        if(box)
+            return box.tooltipText;
+        // SeaMonkey
+        box = document.getElementById("security-button");
+        if(box)
+            return box.tooltipText;
 	},
 
 	clear_existing_banner: function(b, value_text) { 
@@ -788,8 +801,7 @@ var Perspectives = {
 	},
 
 	process_notary_results: function(uri,browser,has_user_permission) {  
-		try { 
- 
+		try {
 			var ti = Perspectives.tab_info_cache[uri.spec]; 
 			ti.notary_valid = false; // default 
 			cache_cert = Perspectives.ssl_cache[uri.host];

--- a/plugin/chrome/content/statusbar.xul
+++ b/plugin/chrome/content/statusbar.xul
@@ -27,7 +27,7 @@
       context="perspective-contextmenu" />
 	</statusbarpanel>
   <popupset>
-    <popup id="perspective-contextmenu" position="after_start">
+    <menupopup id="perspective-contextmenu" position="after_start">
       <menuitem label="View Notary Results"   oncommand="Pers_statusbar.open_results_dialog()"/>
       <menuitem label="Force Notary Check"   oncommand="Pers_statusbar.force_update()"/>
       <menuitem label="Report Attack"   oncommand="Pers_report.report_attack()"/>
@@ -38,7 +38,7 @@
       <menuitem label="View Notary List" oncommand="Pers_statusbar.openNotaries()"/>
       <menuitem label="View Certificate Store" oncommand="Pers_statusbar.openCertificates()"/>
       <menuitem label="Help" oncommand="Pers_statusbar.openHelp()"/>
-    </popup>
+    </menupopup>
   </popupset>
  
 	</statusbar>

--- a/plugin/install.rdf
+++ b/plugin/install.rdf
@@ -18,7 +18,17 @@
 				<em:maxVersion>4.0</em:maxVersion>
 			</Description>
 		</em:targetApplication>
-    <em:localized> 
+
+        <!-- SeaMonkey -->
+        <em:targetApplication>
+            <Description>
+                <em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id>
+                <em:minVersion>2.0</em:minVersion>
+                <em:maxVersion>2.1b</em:maxVersion>
+            </Description>
+        </em:targetApplication>
+
+        <em:localized>
 	<Description> 
 	 <em:locale>en-US</em:locale> 
 		<em:name>Perspectives</em:name>


### PR DESCRIPTION
This patch returns SeaMonkey support.
Stable version of Seamonkey (2.0.x) works just as firefox 3.x, trunk version (2.1x) not work as fireefox trunk (4.x).
