### PR TITLE
Added a toolbar button that can be placed anywhere.

### DIFF
--- a/plugin/chrome/content/statusbar.js
+++ b/plugin/chrome/content/statusbar.js
@@ -66,39 +66,42 @@ var Pers_statusbar = {
 			tooltip = "Perspectives";
 		}
 
-		var i = document.getElementById("perspective-status-image");
+		var imgList = document.querySelectorAll("image.perspective-status-image-class");
+
 		var t = document.getElementById("perspective-status");
-		if(!t || !i){ //happens when called from a dialog
-			i = window.opener.document.
-				getElementById("perspective-status-image");
+		if(!t || !imgList){ //happens when called from a dialog
+			imgList = window.opener.document.
+				querySelectorAll("image.perspective-status-image-class");
 			t = window.opener.document.getElementById("perspective-status");
 		}
 
 		t.setAttribute("tooltiptext", tooltip);
-		switch(state){
-		case Pers_statusbar.STATE_SEC:
-			Pers_debug.d_print("main", "Secure Status\n");
-			i.setAttribute("src", "chrome://perspectives/content/good.png");
-			break;
-		case Pers_statusbar.STATE_NSEC:
-			Pers_debug.d_print("main", "Unsecure Status\n");
-			i.setAttribute("src", "chrome://perspectives/content/bad.png");
-			break;
-		case Pers_statusbar.STATE_NEUT:
-			Pers_debug.d_print("main", "Neutral Status\n");
-			i.setAttribute("src", "chrome://perspectives/content/default.png");
-			break;
-		case Pers_statusbar.STATE_QUERY:
-			Pers_debug.d_print("main", "Querying Status\n");
-			i.setAttribute("src", "chrome://perspectives/content/progress.gif");
-			break;
-		case Pers_statusbar.STATE_ERROR:
-			Pers_debug.d_print("main", "Error Status\n");
-			i.setAttribute("src", "chrome://perspectives/content/error.png");
-			break;
+		for (var j = 0; j < imgList.length; ++j) {
+			switch(state){
+			case Pers_statusbar.STATE_SEC:
+				Pers_debug.d_print("main", "Secure Status\n");
+				imgList[j].setAttribute("src", "chrome://perspectives/content/good.png");
+				continue;
+			case Pers_statusbar.STATE_NSEC:
+				Pers_debug.d_print("main", "Unsecure Status\n");
+				imgList[j].setAttribute("src", "chrome://perspectives/content/bad.png");
+				continue;
+			case Pers_statusbar.STATE_NEUT:
+				Pers_debug.d_print("main", "Neutral Status\n");
+				imgList[j].setAttribute("src", "chrome://perspectives/content/default.png");
+				continue;
+			case Pers_statusbar.STATE_QUERY:
+				Pers_debug.d_print("main", "Querying Status\n");
+				imgList[j].setAttribute("src", "chrome://perspectives/content/progress.gif");
+				continue;
+			case Pers_statusbar.STATE_ERROR:
+				Pers_debug.d_print("main", "Error Status\n");
+				imgList[j].setAttribute("src", "chrome://perspectives/content/error.png");
+				continue;
+			}
+			Pers_debug.d_print("main", "changing tooltip to: " + tooltip + "\n"); 
+			return true;
 		}
-		Pers_debug.d_print("main", "changing tooltip to: " + tooltip + "\n"); 
-		return true;
 	},
 
 	openCertificates: function(){

--- a/plugin/chrome/content/statusbar.xul
+++ b/plugin/chrome/content/statusbar.xul
@@ -22,6 +22,7 @@
       			ondblclick="Pers_statusbar.statusbar_click(event);"
 			tooltiptext="Perspectives">
     <image id="perspective-status-image"
+      class="perspective-status-image-class"
       src="chrome://perspectives/content/default.png" 
       style="width:16px; height:16px;" 
       context="perspective-contextmenu" />
@@ -41,6 +42,33 @@
   </popupset>
  
  </statusbar>
+ 
+ <toolbarpalette id="BrowserToolbarPalette">
+ 	<toolbarbutton 	class="perspective-status"
+ 					tooltiptext="Perspectives"
+ 					id="perspectives-status-button"
+ 					type="menu"
+ 					validate="always"
+ 					label="Perspectives">
+		<!-- <image id="perspective-status-image" /> -->
+		<image 	id="perspective-button-image"
+				class="perspective-status-image-class"
+				src="chrome://perspectives/content/default.png" 
+				style="width:16px; height:16px;" />
+		<menupopup id="perspective-contextmenu-button" position="after_start">
+		  <menuitem label="View Notary Results"   oncommand="Pers_statusbar.open_results_dialog()"/>
+		  <menuitem label="Force Notary Check"   oncommand="Pers_statusbar.force_update()"/>
+		  <menuitem label="Report Attack"   oncommand="Pers_report.report_attack()"/>
+		  <menuitem label="Add to Whitelist"   oncommand="Pers_whitelist_dialog.add_to_whitelist()"/>
+		  <menuseparator/>
+	<!--      <menuitem label="Refresh All Notary Data"   oncommand="requery()"/> --> 
+		  <menuitem label="Preferences" oncommand="Pers_statusbar.open_preferences_dialog()"/>
+		  <menuitem label="View Certificate Store" oncommand="Pers_statusbar.openCertificates()"/>
+		  <menuitem label="Help" oncommand="Pers_statusbar.openHelp()"/>
+		</menupopup>
+	</toolbarbutton>
+ </toolbarpalette>
+ 
 
  <menupopup id="menu_ToolsPopup"> 
 	<menu id="menu_pers_tools" label="Perspectives" insertbefore="javascriptConsole"> 


### PR DESCRIPTION
I put a feature request on the issue tracker here: https://github.com/danwent/Perspectives/issues#issue/28
I implemented it. You can see the button in action next to the address bar in this screen shot: http://i.min.us/ikw9e4.png

Users can find the button in the tray when they customize the toolbar. My own preference is to have it to the left of the address bar so I can see all the security information in one place. I think it's good to have because most users of FF 4 probably don't have the add-on bar.
