### PR TITLE
Localization - fix german file that was not saved as UTF-8

### DIFF
--- a/plugin/chrome/locale/de/amodetails.properties
+++ b/plugin/chrome/locale/de/amodetails.properties
@@ -7,6 +7,6 @@
 #Developers: remember to copy/paste these strings into install.rdf and addons.mozilla.org when creating a new localization.
 
 amoCreator=Perspectives Projekt der Carnegie Mellon Computer Science
-amoDescription=Umgeht HTTPS Sicherheitswarnungen auf sichere Weise, indem die Zertifikate mit Hilfe einer Liste von Netzwerknotaren überprüft werden. Siehe http://www.perspectives-project.org (englischsprachig).
+amoDescription=Umgeht HTTPS Sicherheitswarnungen auf sichere Weise, indem die Zertifikate mit Hilfe einer Liste von Netzwerknotaren Ã¼berprÃ¼ft werden. Siehe http://www.perspectives-project.org (englischsprachig).
 amoMoreInfo=Perspectives stellt eine neue, dezentrale Methode dar, Internet-Servers sicher zu erkennen. Es baut automatisch eine Datenbank von Serveridentit&auml;ten mittels leichtgewichtiger Nachfragen bei "Netzwerknotaren" auf. Diese sind rund um das Internet verbreitete Servers. Jedes Mal, wenn Sie sich an eine sichere Website anschlie&szlig;en, vergleicht Perspectives das Zertifikat, das Sie von ihm bekommen, mit den Daten der Notare - und warnt Sie bei Unstimmigkeiten. So wissen Sie, ob dem Ihnen gegebenen Zertifikat zu trauen ist. Durch Nutzung von Perspectives k&ouml;nnen Sie "Mann-in-der-Mitte"-Angriffe vermeiden; selbstsignierte Zertifikate verwenden; und darauf vertrauen, dass Ihre Verbindungen wirklich sicher sind.
 


### PR DESCRIPTION
These strings aren't used in the plugin directly,
but we should still save things properly.
